### PR TITLE
Decorator Lambda and Tracking Table

### DIFF
--- a/cloudformation/Prowler-Template.yaml
+++ b/cloudformation/Prowler-Template.yaml
@@ -621,7 +621,7 @@ Resources:
       FunctionName: !Sub "${AWS::StackName}-decorator"
       Description: Decorate prowler findings with additional tracking data from DDB
       Handler: decorate_prowler_findings.handler
-      Role: !GetAtt LambdaRole.Arn
+      Role: !GetAtt DecoratorLambdaRole.Arn
       CodeUri: ../lambda
       Timeout: 900
       Events:
@@ -644,7 +644,7 @@ Resources:
       # Any messages older than an hour are probably out-of-date
       MessageRetentionPeriod: 36000
       ReceiveMessageWaitTimeSeconds: 10
-      VisibilityTimeout: 750
+      VisibilityTimeout: 1050
   
   S3EventDecoratorQueueSubscription:
     Type: AWS::SNS::Subscription

--- a/cloudformation/Prowler-Template.yaml
+++ b/cloudformation/Prowler-Template.yaml
@@ -608,10 +608,12 @@ Resources:
           Version: '2012-10-17'
           Statement:
           - Resource:
-            - !GetAtt ProwlerFindingsTrackingTable.Arn
+            - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${ProwlerFindingsTrackingTable}"
+            - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${ProwlerFindingsTrackingTable}/index/*"
             Action:
             - dynamodb:Query
             - dynamodb:PutItem
+            - dynamodb:BatchWriteItem
             - dynamodb:UpdateItem
             Effect: Allow
 
@@ -634,6 +636,7 @@ Resources:
       Environment:
         Variables:
           TRACKING_TABLE_NAME: !Ref ProwlerFindingsTrackingTable
+          OUTPUT_BUCKET: !Ref ProwlerBucket
 
   #
   # Decorator S3 -> SNS -> SQS -> Lambda Plumbing
@@ -834,28 +837,28 @@ Resources:
     Properties:
       TableName: !Ref pTableName
       AttributeDefinitions:
-        - AttributeName: finding_info.uid
+        - AttributeName: finding_info_uid
           AttributeType: S
-        - AttributeName: cloud.account.uid
+        - AttributeName: cloud_account_uid
           AttributeType: S
-        - AttributeName: metadata.event_code
+        - AttributeName: metadata_event_code
           AttributeType: S
       KeySchema:
-        - AttributeName: finding_info.uid
+        - AttributeName: finding_info_uid
           KeyType: HASH
       BillingMode: PAY_PER_REQUEST
       GlobalSecondaryIndexes:
         - IndexName: "CloudAccountIndex"
           KeySchema:
-            - AttributeName: "cloud.account.uid"
+            - AttributeName: cloud_account_uid
               KeyType: "HASH"
-            - AttributeName: "metadata.event_code"
+            - AttributeName: metadata_event_code
               KeyType: "RANGE"
           Projection:
             ProjectionType: "ALL"
         - IndexName: "EventCodeIndex"
           KeySchema:
-            - AttributeName: "metadata.event_code"
+            - AttributeName: metadata_event_code
               KeyType: "HASH"
           Projection:
             ProjectionType: "ALL"

--- a/cloudformation/Prowler-Template.yaml
+++ b/cloudformation/Prowler-Template.yaml
@@ -559,6 +559,152 @@ Resources:
         Variables:
           FINDING_QUEUE_URL: !Ref FindingIngestEventQueue
 
+  DecoratorLambdaRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+        - Effect: Allow
+          Principal:
+            Service:
+            - lambda.amazonaws.com
+          Action:
+          - sts:AssumeRole
+      Path: /
+      Policies:
+      - PolicyName: S3Access
+        PolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+          - Action:
+            - s3:PutObject
+            - s3:GetObject
+            Effect: Allow
+            Resource:
+              - !Sub 'arn:aws:s3:::${pBucketName}/*'
+              - !Sub 'arn:aws:s3:::${pBucketName}'
+      - PolicyName: LambdaLogging
+        PolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+          - Resource: '*'
+            Action:
+            - logs:*
+            Effect: Allow
+      - PolicyName: GetMessages
+        PolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+          - Resource:
+            - !GetAtt S3EventDecoratorQueue.Arn
+            Action:
+            - sqs:ReceiveMessage
+            - sqs:DeleteMessage
+            - sqs:GetQueueAttributes
+            Effect: Allow
+      - PolicyName: DDBFindingTracking
+        PolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+          - Resource:
+            - !GetAtt ProwlerFindingsTrackingTable.Arn
+            Action:
+            - dynamodb:Query
+            - dynamodb:PutItem
+            - dynamodb:UpdateItem
+            Effect: Allow
+
+  DecorateFindingsFunction:
+    Properties:
+      FunctionName: !Sub "${AWS::StackName}-decorator"
+      Description: Decorate prowler findings with additional tracking data from DDB
+      Handler: decorate_prowler_findings.handler
+      Role: !GetAtt LambdaRole.Arn
+      CodeUri: ../lambda
+      Timeout: 900
+      Events:
+        SQSIngest:
+          Type: SQS
+          Properties:
+            BatchSize: 1
+            Enabled: True
+            Queue: !GetAtt S3EventDecoratorQueue.Arn
+      Environment:
+        Variables:
+          TRACKING_TABLE_NAME: !Ref ProwlerFindingsTrackingTable
+
+  #
+  # Decorator S3 -> SNS -> SQS -> Lambda Plumbing
+  #
+  S3EventDecoratorQueue:
+    Type: AWS::SQS::Queue
+    Properties:
+      # Any messages older than an hour are probably out-of-date
+      MessageRetentionPeriod: 36000
+      ReceiveMessageWaitTimeSeconds: 10
+      VisibilityTimeout: 750
+  
+  S3EventDecoratorQueueSubscription:
+    Type: AWS::SNS::Subscription
+    Properties:
+      Endpoint: !GetAtt S3EventDecoratorQueue.Arn
+      Protocol: sqs
+      TopicArn: !Ref OutputNotificationTopic # topic for "prowler4-output/json-ocsf/" events
+
+  S3EventDecoratorQueuePolicy:
+    Type: AWS::SQS::QueuePolicy
+    Properties:
+      Queues:
+        - !Ref S3EventDecoratorQueue
+      PolicyDocument:
+        Version: '2012-10-17'
+        Id: AllowS3
+        Statement:
+        - Sid: AllowS3EventNotification
+          Effect: Allow
+          Principal:
+            AWS: '*'
+          Action:
+          - SQS:SendMessage
+          Resource: !GetAtt S3EventDecoratorQueue.Arn
+          Condition:
+            ArnLike:
+              aws:SourceArn: !Sub "arn:aws:s3:*:*:${pBucketName}"
+        - Sid: Allow-SNS-SendMessage
+          Effect: Allow
+          Principal: "*"
+          Action:
+          - sqs:SendMessage
+          Resource: !GetAtt S3EventDecoratorQueue.Arn
+          Condition:
+            ArnEquals:
+              aws:SourceArn:
+                - !Ref OutputNotificationTopic
+  
+  S3EventDecoratorQueueAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      ActionsEnabled: True
+      AlarmDescription: "Alert when decorator Queue doesn't properly drain"
+      AlarmName: !Sub "${AWS::StackName}-DecoratorFileProcessQueue"
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      Dimensions:
+        - Name: QueueName
+          Value: !GetAtt S3EventDecoratorQueue.QueueName
+      EvaluationPeriods: 1
+      MetricName: ApproximateNumberOfMessagesVisible
+      Namespace: AWS/SQS
+      Period: 300
+      Statistic: Average
+      Threshold: 3
+      TreatMissingData: missing
+      AlarmActions:
+        - !If
+          - cAlarmActions
+          - !Ref pAlertTopicArn
+          - !Ref AWS::NoValue
+
   #
   # S3 -> SNS -> SQS -> Lambda Plumbing
   #
@@ -753,6 +899,28 @@ Resources:
       Dimensions:
       - Name: "FunctionName"
         Value: !Ref ProcessFindingsFileFunction
+      Statistic: "Sum"
+      ComparisonOperator: "GreaterThanThreshold"
+      Threshold: 0
+      EvaluationPeriods: 1
+      Period: 60
+      TreatMissingData: "ignore"
+      AlarmActions:
+        - !If
+          - cAlarmActions
+          - !Ref pAlertTopicArn
+          - !Ref AWS::NoValue
+
+  DecorateFindingsFunctionErrorAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub ${DecorateFindingsFunction}-LambdaErrors
+      AlarmDescription: "Alarm if lambda errors out"
+      Namespace: "AWS/Lambda"
+      MetricName: "Errors"
+      Dimensions:
+      - Name: "FunctionName"
+        Value: !Ref DecorateFindingsFunction
       Statistic: "Sum"
       ComparisonOperator: "GreaterThanThreshold"
       Threshold: 0

--- a/cloudformation/Prowler-Template.yaml
+++ b/cloudformation/Prowler-Template.yaml
@@ -616,6 +616,7 @@ Resources:
             Effect: Allow
 
   DecorateFindingsFunction:
+    Type: AWS::Serverless::Function
     Properties:
       FunctionName: !Sub "${AWS::StackName}-decorator"
       Description: Decorate prowler findings with additional tracking data from DDB

--- a/cloudformation/Prowler-Template.yaml
+++ b/cloudformation/Prowler-Template.yaml
@@ -151,7 +151,9 @@ Resources:
   ProwlerBucket:
     Type: AWS::S3::Bucket
     DeletionPolicy: RetainExceptOnCreate
-    DependsOn: ProwlerBucketNotificationTopicPolicy
+    DependsOn: 
+      - ProwlerBucketNotificationTopicPolicy
+      - ProwlerBucketProcessedFindingsNotificationTopicPolicy
     Properties:
       # AccessControl: Private
       BucketEncryption:
@@ -171,6 +173,15 @@ Resources:
                 Rules:
                   - Name: prefix
                     Value: "prowler4-output/json-ocsf/"
+                  - Name: suffix
+                    Value: ".json"
+          - Event: 's3:ObjectCreated:*'
+            Topic: !Ref ProcessedAWSFindingsNotificationTopic
+            Filter:
+              S3Key:
+                Rules:
+                  - Name: prefix
+                    Value: "prowler4-output/json-ocsf-processed/"
                   - Name: suffix
                     Value: ".json"
           - Event: 's3:ObjectCreated:*'
@@ -209,7 +220,7 @@ Resources:
         - Sid: AllowProwlerBucketPublish
           Effect: Allow
           Principal:
-            AWS: "*"
+            Service: "s3.amazonaws.com"
           Action:
           - SNS:Publish
           Resource:
@@ -220,6 +231,35 @@ Resources:
             StringEquals:
               aws:SourceAccount: !Ref AWS::AccountId
 
+  ProcessedAWSFindingsNotificationTopic:
+    Type: AWS::SNS::Topic
+    Properties:
+      DisplayName: !Sub "Destination of PutObject calls from ${pBucketName}/prowler4-output/json-ocsf-processed/"
+      TopicName: !Sub "${pBucketName}-AWS-Processed-S3Events"
+
+  ProwlerBucketProcessedFindingsNotificationTopicPolicy:
+    Type: AWS::SNS::TopicPolicy
+    Properties:
+      Topics:
+        - !Ref ProcessedAWSFindingsNotificationTopic
+      PolicyDocument:
+        Version: '2012-10-17'
+        Id: AllowProwlerBucket
+        Statement:
+        - Sid: AllowProwlerBucketPublish
+          Effect: Allow
+          Principal:
+            Service: "s3.amazonaws.com"
+          Action:
+          - SNS:Publish
+          Resource:
+          - !Ref ProcessedAWSFindingsNotificationTopic
+          Condition:
+            ArnLike:
+              aws:SourceArn: !Sub "arn:aws:s3:*:*:${pBucketName}"
+            StringEquals:
+              aws:SourceAccount: !Ref AWS::AccountId
+  
   GCPOutputNotificationTopic:
     Type: AWS::SNS::Topic
     Properties:
@@ -238,7 +278,7 @@ Resources:
         - Sid: AllowProwlerBucketPublish
           Effect: Allow
           Principal:
-            AWS: "*"
+            Service: "s3.amazonaws.com"
           Action:
           - SNS:Publish
           Resource:
@@ -1029,6 +1069,9 @@ Outputs:
 
   ProwlerBucketEventTopicArn:
     Value: !Ref OutputNotificationTopic
+
+  ProwlerBucketProcessedEventTopicArn:
+    Value: !Ref ProcessedAWSFindingsNotificationTopic
 
   ProwlerBucketGCPEventTopicArn:
     Value: !Ref GCPOutputNotificationTopic

--- a/cloudformation/Prowler-Template.yaml
+++ b/cloudformation/Prowler-Template.yaml
@@ -22,6 +22,10 @@ Parameters:
     Description: Name of the bucket to hold the prowler results
     Type: String
 
+  pTableName:
+    Description: Name of the DDB table to track the prowler results
+    Type: String
+
   pAuditRoleName:
     Description: Default name of the AssumeRole to assume into accounts
     Type: String
@@ -674,6 +678,43 @@ Resources:
           - cAlarmActions
           - !Ref pAlertTopicArn
           - !Ref AWS::NoValue
+
+  #
+  # DynamoDB resources
+  #
+  ProwlerFindingsTrackingTable:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      TableName: !Ref pTableName
+      AttributeDefinitions:
+        - AttributeName: finding_info.uid
+          AttributeType: S
+        - AttributeName: cloud.account.uid
+          AttributeType: S
+        - AttributeName: metadata.event_code
+          AttributeType: S
+      KeySchema:
+        - AttributeName: finding_info.uid
+          KeyType: HASH
+      BillingMode: PAY_PER_REQUEST
+      GlobalSecondaryIndexes:
+        - IndexName: "CloudAccountIndex"
+          KeySchema:
+            - AttributeName: "cloud.account.uid"
+              KeyType: "HASH"
+            - AttributeName: "metadata.event_code"
+              KeyType: "RANGE"
+          Projection:
+            ProjectionType: "ALL"
+        - IndexName: "EventCodeIndex"
+          KeySchema:
+            - AttributeName: "metadata.event_code"
+              KeyType: "HASH"
+          Projection:
+            ProjectionType: "ALL"
+      StreamSpecification:
+        StreamViewType: NEW_IMAGE
+    DeletionPolicy: RetainExceptOnCreate
 
   #
   # Alarms

--- a/lambda/decorate_prowler_findings.py
+++ b/lambda/decorate_prowler_findings.py
@@ -111,7 +111,9 @@ def process_account_findings(findings_to_process: List[Dict]) -> List[Dict]:
         if finding_uid not in finding_uids:
             logger.debug(f"finding uid {finding_uid} not found in dynamodb, adding to table")
             f["start_time"] = f["event_time"]
-            processed_findings.append(f)
+            ddb_finding = f
+            ddb_finding.pop("unmapped")
+            processed_findings.append(ddb_finding)
             # Don't want to add these to the output file (unnecessary), but do want them to be added to DDB
             f["finding_info_uid"] = f["finding_info"]["uid"]
             f["metadata_event_code"] = f["metadata"]["event_code"]

--- a/lambda/decorate_prowler_findings.py
+++ b/lambda/decorate_prowler_findings.py
@@ -1,0 +1,34 @@
+# Copyright 2023 Chris Farris <chrisf@primeharbor.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import boto3
+import json
+import os
+
+from common import get_object
+
+import logging
+logger = logging.getLogger()
+logger.setLevel(getattr(logging, os.getenv('LOG_LEVEL', default='INFO')))
+logging.getLogger('botocore').setLevel(logging.WARNING)
+logging.getLogger('boto3').setLevel(logging.WARNING)
+logging.getLogger('urllib3').setLevel(logging.WARNING)
+
+
+# Lambda execution starts here
+def handler(event, context):
+    logger.debug("Received event: " + json.dumps(event, sort_keys=True))
+
+    return True
+

--- a/lambda/decorate_prowler_findings.py
+++ b/lambda/decorate_prowler_findings.py
@@ -40,7 +40,6 @@ logger.info("decorate_prowler_findings initiated")
 def handler(event, context):
     logger.debug("Received event: " + json.dumps(event, sort_keys=True))
 
-    logger.info(f"received {len[event['Records']]} records to process")
     for record in event["Records"]:
         body = json.loads(record["body"])
         if "Message" in body:

--- a/lambda/decorate_prowler_findings.py
+++ b/lambda/decorate_prowler_findings.py
@@ -12,23 +12,123 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import boto3
+
 import json
-import os
-
-from common import get_object
-
 import logging
+import os
+from typing import Dict, List
+
+from boto3.dynamodb.conditions import Key
+
+from common import DynamoDBTable, get_object, put_dict_object
+
+
 logger = logging.getLogger()
 logger.setLevel(getattr(logging, os.getenv('LOG_LEVEL', default='INFO')))
 logging.getLogger('botocore').setLevel(logging.WARNING)
 logging.getLogger('boto3').setLevel(logging.WARNING)
 logging.getLogger('urllib3').setLevel(logging.WARNING)
 
+# Using environ to raise KeyError if not provided
+TABLE_NAME = os.environ["TRACKING_TABLE_NAME"]
+OUTPUT_BUCKET = os.environ["OUTPUT_BUCKET"]
+OUTPUT_PREFIX = "prowler4-output/json-ocsf-processed/"
+
+logger.info("decorate_prowler_findings initiated")
 
 # Lambda execution starts here
 def handler(event, context):
     logger.debug("Received event: " + json.dumps(event, sort_keys=True))
 
-    return True
+    logger.info(f"received {len[event['Records']]} records to process")
+    for record in event["Records"]:
+        body = json.loads(record["body"])
+        if "Message" in body:
+            message = json.loads(body["Message"])
+            if message.get("Event") == "s3:TestEvent":
+                logger.warning(f"Received Test Event. Doing Nothing.")
+                continue
+            s3_records = message["Records"]
+        else:
+            s3_records = body["Records"]
 
+        logger.info(f"received {len(s3_records)} S3 objects to process")
+        # Is there a possibility for many objects here?
+        for s3_record in s3_records:
+            bucket = s3_record['s3']['bucket']['name']
+            obj_key = s3_record['s3']['object']['key']
+            file_name = os.path.basename(obj_key)
+            output_key = f"{OUTPUT_PREFIX}{file_name}"
+
+            logger.info(f"Processing file s3://{bucket}/{obj_key}")
+            findings_to_process = get_object(bucket, obj_key)
+            if not findings_to_process:
+                raise Exception(f"Failed to get s3://{bucket}/{obj_key}") # This will force a requeue?
+
+            logger.info(f"{len(findings_to_process)} findings to process in s3://{bucket}/{obj_key}")
+            processed_findings = process_account_findings(findings_to_process)
+            logger.info(f"writing findings to s3://{OUTPUT_BUCKET}/{output_key}")
+            put_dict_object(OUTPUT_BUCKET, output_key, processed_findings)
+            
+
+def process_account_findings(findings_to_process: List[Dict]) -> List[Dict]:
+    """
+    Given a list of Prowler findings for an AWS account:
+        - Looks up all findings for the AWS account in DynamoDB
+        - If not in DynamoDB, adds a start_time field to the finding (from the event_time). Adds the finding to DDB.
+        - If in DynamoDB, adds the start_time field from DynamoDB to the finding
+    Important assumption that all findings are from the same account.
+
+    Args:
+        findings_to_process (List[Dict]): List of prowler dictionary findings
+
+    Returns:
+        processed_findings (List[Dict]): List of prowler dictionary findings with additional fields from DDB
+    """
+    table_handler = DynamoDBTable(TABLE_NAME)
+
+    logger.info(f"processing {len(findings_to_process)} findings")
+    # Query for all findings just from the account number
+    account_id = findings_to_process[0]["cloud"]["account"]["uid"]
+    account_findings: Dict = table_handler.table.query(
+        IndexName="CloudAccountIndex",
+        KeyConditionExpression=Key("cloud_account_uid").eq(account_id),
+        ProjectionExpression="finding_info_uid, cloud_account_uid, metadata_event_code, start_time"
+    )
+    finding_uids = []
+    for item in account_findings.get("Items", {}):
+        finding_uids.append(item.get("finding_info_uid"))
+
+    findings_to_add = []
+    processed_findings = []
+    for f in findings_to_process:
+        finding_uid = f["finding_info"]["uid"]
+        # If the finding is PASS/MANUAL, just write to output file as-is
+        if f["status_code"] != "FAIL":
+            logger.debug(f"finding uid {finding_uid} status is {f['status_code']}, skipping")
+            processed_findings.append(f)
+            continue
+        
+        if finding_uid not in finding_uids:
+            logger.debug(f"finding uid {finding_uid} not found in dynamodb, adding to table")
+            f["start_time"] = f["event_time"]
+            processed_findings.append(f)
+            # Don't want to add these to the output file (unnecessary), but do want them to be added to DDB
+            f["finding_info_uid"] = f["finding_info"]["uid"]
+            f["metadata_event_code"] = f["metadata"]["event_code"]
+            f["cloud_account_uid"] = f["cloud"]["account"]["uid"]
+            findings_to_add.append(f)
+            continue
+        
+        logger.debug(f"finding uid {finding_uid} found in dynamodb")
+        start_time = item["start_time"]
+        logger.debug(f"finding uid {finding_uid} has a dynamodb start time of {start_time}, adding to output file")
+        f["start_time"] = item["start_time"]
+        processed_findings.append(f)
+
+    logger.debug(f"adding {len(findings_to_add)} findings to dynamodb")
+    table_handler.batch_write_items(findings_to_add)
+
+    logger.info(f"processed {len(processed_findings)} findings")
+
+    return processed_findings

--- a/scripts/backfill_prowler_findings.py
+++ b/scripts/backfill_prowler_findings.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+# Copyright 2023 Chris Farris <chris@primeharbor.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import concurrent.futures
+import json
+import logging
+import os
+import re
+from typing import Dict, List, Optional
+
+import boto3
+from boto3.dynamodb.conditions import Key
+from urllib.parse import unquote
+
+
+logger = logging.getLogger()
+logger.setLevel(getattr(logging, os.getenv('LOG_LEVEL', default='DEBUG')))
+logging.getLogger('botocore').setLevel(logging.WARNING)
+logging.getLogger('boto3').setLevel(logging.WARNING)
+logging.getLogger('urllib3').setLevel(logging.WARNING)
+
+file_handler = logging.FileHandler("backfill_output.log")
+formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+file_handler.setFormatter(formatter)
+logger.addHandler(file_handler)
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--profile", help="AWS profile to use")
+parser.add_argument("--bucket", help="S3 bucket where findings are", required=True)
+parser.add_argument("--table-name", help="DynamoDB table to write output", required=True)
+parser.add_argument("--prefix", help="Prefix where json files live in bucket", default="prowler4-output/json-ocsf/")
+
+
+args = parser.parse_args()
+
+
+s3 = boto3.client("s3")
+
+def list_objects(bucket, prefix) -> List[str]:
+    objects = []
+    paginator = s3.get_paginator("list_objects_v2")
+    for page in paginator.paginate(Bucket=bucket, Prefix=prefix):
+        if "Contents" in page:
+            for obj in page["Contents"]:
+                objects.append(obj["Key"])
+
+    return objects
+
+def get_json_object(bucket, obj_key) -> List[Dict]:
+    response = s3.get_object(Bucket=bucket, Key=unquote(obj_key))
+
+    return json.loads(response["Body"].read())
+
+class DynamoDBTable:
+    """
+    General wrapper for DynamoDB operations
+    """
+    def __init__(self, table_name: str) -> None:
+        self.table_name = table_name
+        dynamodb = boto3.resource("dynamodb")
+        self.table = dynamodb.Table(self.table_name)
+
+    def batch_write_items(self, items: List[Dict], batch_size: Optional[int] = 25) -> None:
+        """
+        Given a list of dictionaries, batch write them all to the table
+
+        Args:
+            items (List[Dict]): list of dictionaries to write
+            batch_size (Optional[int]): size of the batches to write. Default (and max) is 25
+        """
+        if batch_size > 25:
+            batch_size = 25
+            
+        logger.info(f"writing {len(items)} items to DynamoDB table {self.table_name}")
+
+        written_items = 0
+        for i in range(0, len(items), batch_size):
+            batch = items[i:i+batch_size]
+            written_items += len(batch)
+            with self.table.batch_writer() as batch_writer:
+                for item in batch:
+                    try:
+                        batch_writer.put_item(Item=item)
+                    except Exception:
+                        logger.exception(f"error writing {item} to dynamodb")
+                        raise
+        
+        logger.info(f"wrote {written_items} items to DynamoDB table {self.table_name}")
+
+def process_findings_for_account(account: str, account_files: List[str], table_handler: DynamoDBTable, account_finding_uids: Dict):
+    findings_to_add = []
+    with concurrent.futures.ThreadPoolExecutor() as executor:
+        future_to_s3 = {executor.submit(get_json_object, args.bucket, obj_name): obj_name for obj_name in account_files}
+        for future in concurrent.futures.as_completed(future_to_s3):
+            obj_name = future_to_s3[future]
+            try:
+                s3_findings = future.result()
+                for s3_finding in s3_findings:
+                    process_single_finding(s3_finding, account_finding_uids, findings_to_add)
+            except Exception as e:
+                logger.error(f"Error processing {obj_name}: {e}")
+
+    logger.info(f"{len(findings_to_add)} findings to add or replace for account {account}")
+    # there may have been multiple days where the finding appears, need to only keep the newest one
+    deduped_findings = {}
+    for finding in findings_to_add:
+        if finding["finding_info_uid"] in deduped_findings:
+            if finding["start_time"] < deduped_findings[finding["finding_info_uid"]]["start_time"]:
+                deduped_findings[finding["finding_info_uid"]] = finding
+        else:
+            deduped_findings[finding["finding_info_uid"]] = finding
+    
+    logger.info(f"{len(deduped_findings)} unique findings to add or replace for account {account}")
+    table_handler.batch_write_items(list(deduped_findings.values()))
+
+def process_single_finding(s3_finding: Dict, account_finding_uids: Dict, findings_to_add: List):
+    s3_finding_uid = s3_finding["finding_info"]["uid"]
+    if s3_finding["status_code"] != "FAIL":
+        logger.debug(f"finding uid {s3_finding_uid} status is {s3_finding['status_code']}, skipping")
+        return
+
+    s3_finding.pop("unmapped")
+    s3_finding["finding_info_uid"] = s3_finding["finding_info"]["uid"]
+    s3_finding["metadata_event_code"] = s3_finding["metadata"]["event_code"]
+    s3_finding["cloud_account_uid"] = s3_finding["cloud"]["account"]["uid"]
+    s3_finding["start_time"] = s3_finding["event_time"]
+    # if finding not in account_findings, add to DDB
+    if s3_finding_uid not in account_finding_uids:
+        logger.info(f"finding uid {s3_finding_uid} doesn't exist in DDB, adding to table")
+        findings_to_add.append(s3_finding)
+    # if finding in account_findings, compare start_time
+    else:
+        # if start_time in file finding is earlier than DDB, replace DDB finding (remove unmapped field)
+        s3_event_time = s3_finding["event_time"]
+        if s3_event_time < account_finding_uids[s3_finding_uid]:
+            logger.info(f"finding uid {s3_finding_uid}'s start time in DDB ({account_finding_uids[s3_finding_uid]}) is later than the S3 start time ({s3_event_time}). Replacing in DDB")
+            findings_to_add.append(s3_finding)
+        else:
+            logger.info(f"finding uid {s3_finding_uid}'s start time in DDB ({account_finding_uids[s3_finding_uid]}) is earlier than the S3 start time ({s3_event_time}). Skipping")
+
+def main():
+    table_handler = DynamoDBTable(args.table_name)
+
+    file_name_account_id_regex = r'\b\d{12}\b'
+    objects = list_objects(args.bucket, args.prefix)
+    account_files = {}
+    for object in objects:
+        match = re.search(file_name_account_id_regex, object)
+        account_number = match.group(0)
+        account_files.setdefault(account_number, []).append(object)
+
+    for account, account_object_names in account_files.items():
+        logger.info(f"backfilling findings for account {account}")
+        
+        # query once for the whole account so we can reduce DDB interaction
+        account_findings: Dict = table_handler.table.query(
+            IndexName="CloudAccountIndex",
+            KeyConditionExpression=Key("cloud_account_uid").eq(account),
+            ProjectionExpression="finding_info_uid, cloud_account_uid, metadata_event_code, start_time"
+        )
+        account_finding_uids = {item["finding_info_uid"]: item["start_time"] for item in account_findings.get("Items", {})}
+
+        process_findings_for_account(account, account_object_names, table_handler, account_finding_uids)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adding a few things:

- DynamoDB table
    - global index for account number is important - will be used in lambda to query for all findings for the account
- Lambda role for new decorator function which allows 
     - gets/puts to/from S3 bucket
     - read/write to/from DynamoDB table
     - pulling messages from new SQS sub
- SQS sub to already-created SNS fan triggered from object puts to `/prowler4output/json-ocsf`
- Lambda function that processes objects
    - Looks up all findings for the AWS account in DynamoDB - one-time query
    - If not in DynamoDB, adds a start_time field to the finding (from the event_time)
    - If in DynamoDB, adds the start_time field from DynamoDB to the finding
    - Ultimately batch adds all findings that were not previously in dynamodb